### PR TITLE
Fix/progress tracking fails

### DIFF
--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -85,6 +85,13 @@ var (
 				OnDelete:   schema.SetNull,
 			},
 		},
+		Indexes: []*schema.Index{
+			{
+				Name:    "progress_user_id_item_id",
+				Unique:  true,
+				Columns: []*schema.Column{ProgressesColumns[4], ProgressesColumns[3]},
+			},
+		},
 	}
 	// TagsColumns holds the columns for the "tags" table.
 	TagsColumns = []*schema.Column{

--- a/ent/schema/progress.go
+++ b/ent/schema/progress.go
@@ -4,6 +4,7 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
+	"entgo.io/ent/schema/index"
 )
 
 // Progress holds the schema definition for the user progress entity.
@@ -26,5 +27,12 @@ func (Progress) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("item", Meta.Type).Ref("progress").Unique().Field("item_id"),
 		edge.From("user", User.Type).Ref("progress").Unique().Field("user_id"),
+	}
+}
+
+func (Progress) Indexes() []ent.Index {
+	return []ent.Index{
+		// Index for user progress
+		index.Fields("user_id", "item_id").Unique(),
 	}
 }

--- a/server/manga.go
+++ b/server/manga.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/disintegration/imaging"
 	"github.com/mangaweb4/mangaweb4-backend/container"
@@ -22,6 +23,7 @@ import (
 )
 
 type MangaServer struct {
+	progressMutex sync.Mutex
 	grpc.UnimplementedMangaServer
 }
 
@@ -313,6 +315,9 @@ func (s *MangaServer) PageImage(ctx context.Context, req *grpc.MangaPageImageReq
 
 	u, err := user.GetUser(ctx, client, req.User)
 	if err == nil {
+		s.progressMutex.Lock()
+		defer s.progressMutex.Unlock()
+
 		progressRec, _ := client.Progress.Query().Where(progress.UserID(u.ID), progress.ItemID(m.ID)).Only(ctx)
 
 		if progressRec == nil {


### PR DESCRIPTION
See #3 . When the item is open for the first time, it's possible that multiple requests are made at the same time. With the lack of mutex at creating progress, multiple `progresses` records might be created at the same time. 

This causes read items diplay as new items.

By this code fix it uses a mutex to prevent multiple record to be created.

